### PR TITLE
stop creation of users with no speciality

### DIFF
--- a/src/services/users/users.hooks.js
+++ b/src/services/users/users.hooks.js
@@ -2,6 +2,8 @@ const { authenticate } = require('@feathersjs/authentication').hooks;
 
 const { hashPassword, protect } = require('@feathersjs/authentication-local').hooks;
 
+const { disallow } = require('feathers-hooks-common');
+
 const permission = require('../../hooks/permission');
 
 module.exports = {
@@ -9,7 +11,7 @@ module.exports = {
     all: [authenticate('jwt'), permission({ roles: 'admin' })],
     find: [],
     get: [],
-    create: [hashPassword()],
+    create: [disallow('external'), hashPassword()],
     update: [hashPassword()],
     patch: [hashPassword()],
     remove: [],


### PR DESCRIPTION
users can now only be created by the server unless one of the admin, manager or coach endpoints is used
closes #58 