### PR TITLE
Fixed coach find

### DIFF
--- a/src/hooks/userhooks.js
+++ b/src/hooks/userhooks.js
@@ -10,8 +10,7 @@ module.exports = {
   limitQuery: role => (context) => {
     const query = context.params.query || {};
 
-    query[role] = query[role] || {};
-    query[role].is = true;
+    query[`${role}.is`] = true;
 
     context.params.query = query;
     return context;


### PR DESCRIPTION
Feedback was causing finding coaches to break.

This fixed it for some reason.
`    query[`${role}.is`] = true;
`
We good now