### PR TITLE
Updated error messages

### DIFF
--- a/src/models/regions.model.js
+++ b/src/models/regions.model.js
@@ -49,7 +49,7 @@ module.exports = (app) => {
       timestamps: true,
     },
   );
-  regions.plugin(uniqueValidator);
+  regions.plugin(uniqueValidator, { message: 'Region \'{VALUE}\' already exists.' });
 
   return mongooseClient.model('regions', regions);
 };

--- a/src/models/users.model.js
+++ b/src/models/users.model.js
@@ -98,7 +98,7 @@ module.exports = (app) => {
       timestamps: true,
     },
   );
-  users.plugin(uniqueValidator);
+  users.plugin(uniqueValidator, { message: 'That {PATH} is already registered to a user.' });
 
   return mongooseClient.model('users', users);
 };


### PR DESCRIPTION
Now a unique conflict error will return ready to display messages.
To access it from in the front end you may need to use ValidationError.errors.email.message for users and ValidationError.errors.name.message for regions. This may be able to be bypassed somehow.

This is what the object looks like:
`{
    "name": "BadRequest",
    "message": "regions validation failed: name: Region 'Heko' already exists.",
    "code": 400,
    "className": "bad-request",
    "errors": {
        "name": 
            "message": "Region 'South Luke' already exists.",
            "name": "ValidatorError",
            "properties": {
                "message": "Region 'South Luke' already exists.",
                "type": "unique",
                "path": "name",
                "value": "South Luke"
            },
            "kind": "unique",
            "path": "name",
            "value": "South Luke"
        }
    }
}`

With the unique validator plugin you seem to only be able to edit the 'Properties' object
Fixes #92 