### PR TITLE
User hook permissions fixed

### DIFF
--- a/src/services/users/users.hooks.js
+++ b/src/services/users/users.hooks.js
@@ -8,13 +8,13 @@ const permission = require('../../hooks/permission');
 
 module.exports = {
   before: {
-    all: [authenticate('jwt'), permission({ roles: 'admin' })],
-    find: [],
-    get: [],
-    create: [hashPassword(), disallow('external')],
-    update: [hashPassword()],
-    patch: [hashPassword()],
-    remove: [],
+    all: [authenticate('jwt')],
+    find: [permission({ roles: ['admin'] })],
+    get: [permission({ roles: ['admin', 'manager', 'coach'] })],
+    create: [hashPassword(), permission({ roles: ['admin'] }), disallow('external')],
+    update: [hashPassword(), permission({ roles: ['admin'] })],
+    patch: [hashPassword(), permission({ roles: ['admin'] })],
+    remove: [permission({ roles: ['admin'] })],
   },
 
   after: {


### PR DESCRIPTION
User hook permissions were causing authentication get requests to be denied causing extreme damage and very much confusion.
Now it is fixed and all is well.
Fixes #113 