### PR TITLE
Verified patch and find with slug

### DIFF
--- a/src/hooks/userhooks.js
+++ b/src/hooks/userhooks.js
@@ -26,6 +26,16 @@ module.exports = {
     return context.id === user._id.toString();
   },
   /**
+  * Returns true if a query contains a verify token
+  * @param {Object} context Context object passed from server
+  */
+  hasVerifyToken: () => async (context) => {
+    if (context.method !== 'find') {
+      throw new GeneralError('verifyRegisterToken should only be used in a find hook.');
+    }
+    return typeof context.params.query.verifyToken !== 'undefined';
+  },
+  /**
   * Blocks patch requests with incorrect verify tokens
   * @param {Object} context Context object passed from server
   */

--- a/src/hooks/userhooks.js
+++ b/src/hooks/userhooks.js
@@ -1,6 +1,4 @@
-// Use this hook to manipulate incoming or outgoing data.
-// For more information on hooks see: http://docs.feathersjs.com/api/hooks.html
-const { GeneralError } = require('@feathersjs/errors');
+const { GeneralError, NotAuthenticated, Forbidden } = require('@feathersjs/errors');
 
 module.exports = {
 /**
@@ -27,7 +25,33 @@ module.exports = {
     const { user } = context.params;
     return context.id === user._id.toString();
   },
-
+  /**
+  * Limits the query to only effect the user
+  * matching the provided slug verify token
+  * @param {Object} context Context object passed from server
+  */
+  limitBySlug: () => async (context) => {
+    if (context.method !== 'patch') {
+      throw new GeneralError('limitBySlug should only be used in a patch hook.');
+    }
+    if (!context.data.tempAuth) {
+      throw new NotAuthenticated('No verify token provided.');
+    }
+    await context.app.services.users.find({
+      query: {
+        verifyToken: context.data.tempAuth,
+      },
+    }).then((user) => {
+      if (user.total === 1) {
+        if (context.id !== user.data[0]._id.toString()) {
+          throw new Forbidden('Verify token provided does not match queried user.');
+        }
+      } else {
+        throw new NotAuthenticated('Invalid verify token provided.');
+      }
+    });
+    return context;
+  },
   /**
   * Removes fields from context.data
   * @param {Object} context Context object passed from server

--- a/src/hooks/userhooks.js
+++ b/src/hooks/userhooks.js
@@ -26,13 +26,12 @@ module.exports = {
     return context.id === user._id.toString();
   },
   /**
-  * Limits the query to only effect the user
-  * matching the provided slug verify token
+  * Blocks patch requests with incorrect verify tokens
   * @param {Object} context Context object passed from server
   */
-  limitBySlug: () => async (context) => {
+  verifyRegisterToken: () => async (context) => {
     if (context.method !== 'patch') {
-      throw new GeneralError('limitBySlug should only be used in a patch hook.');
+      throw new GeneralError('verifyRegisterToken should only be used in a patch hook.');
     }
     if (!context.data.tempAuth) {
       throw new NotAuthenticated('No verify token provided.');

--- a/src/models/users.model.js
+++ b/src/models/users.model.js
@@ -48,7 +48,7 @@ module.exports = (app) => {
         type: String, // TODO add ethnicity options
       },
       DOB: {
-        type: Date,
+        type: Date, // YYYY-MM-DDTHH:MM:SS.MMMZ
       },
       darktheme: {
         type: Boolean,

--- a/src/services/users/admin.hooks.js
+++ b/src/services/users/admin.hooks.js
@@ -36,7 +36,7 @@ module.exports = {
         }
       }),
     ],
-    update: [hashPassword()],
+    update: [hashPassword()], // Disabled
     patch: [
       iff(
         isProvider('external'),

--- a/src/services/users/coach.hooks.js
+++ b/src/services/users/coach.hooks.js
@@ -48,7 +48,7 @@ module.exports = {
               throw new Forbidden('Manager must have a region');
             }))),
     ],
-    update: [hashPassword()],
+    update: [hashPassword()], // Disabled
     patch: [
       hashPassword(),
       permission({ roles: ['admin', 'manager', 'coach'] }),

--- a/src/services/users/manager.hooks.js
+++ b/src/services/users/manager.hooks.js
@@ -38,7 +38,7 @@ module.exports = {
         rec.manager.is = true;
       }),
     ],
-    update: [hashPassword()],
+    update: [hashPassword()], // Disabled
     patch: [
       iff(
         isProvider('external'),

--- a/src/services/users/users.hooks.js
+++ b/src/services/users/users.hooks.js
@@ -2,12 +2,13 @@ const { authenticate } = require('@feathersjs/authentication').hooks;
 const { hashPassword, protect } = require('@feathersjs/authentication-local').hooks;
 const {
   iff,
+  isNot,
   isProvider,
   preventChanges,
   disallow,
 } = require('feathers-hooks-common');
 const verifyHooks = require('feathers-authentication-management').hooks;
-const { verifyRegisterToken } = require('../../hooks/userhooks');
+const { verifyRegisterToken, hasVerifyToken } = require('../../hooks/userhooks');
 const permission = require('../../hooks/permission');
 const accountService = require('../authmanagement/notifier');
 
@@ -15,7 +16,12 @@ const accountService = require('../authmanagement/notifier');
 module.exports = {
   before: {
     all: [],
-    find: [],
+    find: [
+      iff(isProvider('external'),
+        iff(isNot(hasVerifyToken()),
+          authenticate('jwt'),
+          permission({ roles: ['admin'] }))),
+    ],
     get: [authenticate('jwt'), permission({ roles: ['admin', 'manager', 'coach'] })],
     create: [
       hashPassword(),

--- a/src/services/users/users.hooks.js
+++ b/src/services/users/users.hooks.js
@@ -7,28 +7,25 @@ const {
   disallow,
 } = require('feathers-hooks-common');
 const verifyHooks = require('feathers-authentication-management').hooks;
+const { limitBySlug } = require('../../hooks/userhooks');
 const permission = require('../../hooks/permission');
 const accountService = require('../authmanagement/notifier');
 
 
 module.exports = {
   before: {
-    all: [authenticate('jwt')],
-    find: [permission({ roles: ['admin'] })],
-    get: [permission({ roles: ['admin', 'manager', 'coach'] })],
+    all: [],
+    find: [],
+    get: [authenticate('jwt'), permission({ roles: ['admin', 'manager', 'coach'] })],
     create: [
       hashPassword(),
-      permission({ roles: ['admin'] }),
       disallow('external'),
-      iff(
-        isProvider('external'),
-        verifyHooks.addVerification(),
-      ),
     ],
-    update: [hashPassword()],
+    update: [hashPassword()], // Disabled
     patch: [
       iff(
         isProvider('external'),
+        hashPassword(),
         preventChanges(
           true,
           'email',
@@ -41,9 +38,8 @@ module.exports = {
           'resetShortToken',
           'resetExpires',
         ),
-        hashPassword(),
+        limitBySlug(),
       ),
-      permission({ roles: ['admin'] }),
     ],
     remove: [permission({ roles: ['admin'] })],
   },

--- a/src/services/users/users.hooks.js
+++ b/src/services/users/users.hooks.js
@@ -41,7 +41,7 @@ module.exports = {
         limitBySlug(),
       ),
     ],
-    remove: [permission({ roles: ['admin'] })],
+    remove: [authenticate('jwt'), permission({ roles: ['admin'] })],
   },
 
   after: {

--- a/src/services/users/users.hooks.js
+++ b/src/services/users/users.hooks.js
@@ -7,7 +7,7 @@ const {
   disallow,
 } = require('feathers-hooks-common');
 const verifyHooks = require('feathers-authentication-management').hooks;
-const { limitBySlug } = require('../../hooks/userhooks');
+const { verifyRegisterToken } = require('../../hooks/userhooks');
 const permission = require('../../hooks/permission');
 const accountService = require('../authmanagement/notifier');
 
@@ -38,7 +38,7 @@ module.exports = {
           'resetShortToken',
           'resetExpires',
         ),
-        limitBySlug(),
+        verifyRegisterToken(),
       ),
     ],
     remove: [authenticate('jwt'), permission({ roles: ['admin'] })],


### PR DESCRIPTION
Contains the two method updates allowing for unauthenticated registration of user details.
```hasVerifyToken``` Is used in the find hook to assure any unauthenticated users cannot access the user data without providing a verifytoken in their query.
```verifyRegisterToken``` Is used in the patch hook to assure the user the request is attempting to patch corresponds to the verifyToken provided in the request.
Fixes #144 